### PR TITLE
Add [MinimumPerl] plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -44,6 +44,7 @@ copyright = 1
 
 ; -- dynamic meta information
 [MetaProvides::Package]
+[MinimumPerl]
 
 ; -- generate meta/build files
 [License]


### PR DESCRIPTION
Hi,

I got IO::Socket::TimeOut in the Pull Request Challenge this month. I haven't had time to look at the code in detail, but I noticed that you're losing a Kwalitee point by not including the minimum supported Perl version in META.yml. This (really simple) patch uses Dist::Zilla::Plugin::MinimumVersion to fix that.

Hopefully I'll have time to do more work on the module before the end of the month, but I wanted to get at least one PR sent in.

Cheers,

Dave...